### PR TITLE
Parallelization of RPC calls

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from functools import partial
 from typing import List, Tuple
+import time
 
 import hivemind
 from flask import Flask, jsonify, render_template, request
@@ -39,6 +40,7 @@ class ServerInfo:
     friendly_peer_id: str = None
     throughput: float = None
     blocks: List[Tuple[int, ServerState]] = field(default_factory=list)
+    model: str = None
 
 
 @app.route("/")
@@ -48,6 +50,7 @@ def main_page():
 
 @app.route("/health")
 def health():
+    start_time = time.time()
     bootstrap_peer_ids = []
     for addr in INITIAL_PEERS:
         peer_id = hivemind.PeerID.from_base58(Multiaddr(addr)["p2p"])
@@ -55,40 +58,44 @@ def health():
             bootstrap_peer_ids.append(peer_id)
 
     rpc_infos = dht.run_coroutine(partial(check_reachability_parallel, bootstrap_peer_ids))
+    all_bootstrap_reachable = all(rpc_infos[peer_id]["ok"] for peer_id in bootstrap_peer_ids)
+
+    block_ids = []
+    for model in MODELS:
+        block_ids += [f"{model.name}.{i}" for i in range(model.n_blocks)]
+
+    module_infos = get_remote_module_infos(
+        dht,
+        block_ids,
+        float("inf"),
+    )
+
+    servers = defaultdict(ServerInfo)
+    n_found_blocks = defaultdict(int)
+    for info in module_infos:
+        if info is None:
+            continue
+
+        model_name, block_idx_str = info.uid.split('.')
+        found = False
+        for peer_id, server in info.servers.items():
+            servers[peer_id].throughput = server.throughput
+            servers[peer_id].blocks.append((int(block_idx_str), server.state))
+            servers[peer_id].model = model_name
+            if server.state == ServerState.ONLINE:
+                found = True
+        n_found_blocks[model_name] += found
+
+    rpc_infos.update(dht.run_coroutine(partial(check_reachability_parallel, list(servers.keys()), fetch_info=True)))
 
     model_reports = []
     for model in MODELS:
-        module_infos = get_remote_module_infos(
-            dht,
-            [f"{model.name}.{i}" for i in range(model.n_blocks)],
-            float("inf"),
-        )
-
-        servers = defaultdict(ServerInfo)
-        n_found_blocks = 0
-        for block_idx, info in enumerate(module_infos):
-            if info is None:
-                continue
-
-            found = False
-            for peer_id, server in info.servers.items():
-                servers[peer_id].throughput = server.throughput
-                servers[peer_id].blocks.append((block_idx, server.state))
-                if server.state == ServerState.ONLINE:
-                    found = True
-            n_found_blocks += found
-        all_blocks_found = n_found_blocks == model.n_blocks
-
-        rpc_infos.update(dht.run_coroutine(partial(check_reachability_parallel, list(servers.keys()), fetch_info=True)))
-
-        all_bootstrap_reachable = all(rpc_infos[peer_id]["ok"] for peer_id in bootstrap_peer_ids)
+        all_blocks_found = n_found_blocks[model.name] == model.n_blocks
         model_state = "healthy" if all_blocks_found and all_bootstrap_reachable else "broken"
-        bootstrap_states = "".join(
-            get_state_html("online" if rpc_infos[peer_id]["ok"] else "unreachable") for peer_id in bootstrap_peer_ids
-        )
 
         server_rows = []
-        for peer_id, server_info in sorted(servers.items()):
+        model_servers = [(peer_id, server_info) for peer_id, server_info in servers.items() if server_info.model == model.name]
+        for peer_id, server_info in sorted(model_servers):
             block_indices = [block_idx for block_idx, state in server_info.blocks if state != ServerState.OFFLINE]
             block_indices = f"{min(block_indices)}:{max(block_indices) + 1}" if block_indices else ""
 
@@ -121,6 +128,10 @@ def health():
             "server_rows": server_rows,
         })
 
+    bootstrap_states = "".join(
+        get_state_html("online" if rpc_infos[peer_id]["ok"] else "unreachable") for peer_id in bootstrap_peer_ids
+    )
+
     reachability_issues = [
         {"peer_id": peer_id, "err": info["error"]}
         for peer_id, info in sorted(rpc_infos.items())
@@ -133,6 +144,7 @@ def health():
         bootstrap_states=bootstrap_states,
         model_reports=model_reports,
         reachability_issues=reachability_issues,
+        gen_time=(time.time() - start_time),
     )
 
 

--- a/templates/health.html
+++ b/templates/health.html
@@ -118,4 +118,5 @@ $(() => {
 });
 </script>
 
-<footer>You can find this tool's source code on <a target="_blank" href="https://github.com/borzunov/health.petals.ml">GitHub</a>.</footer>
+<footer>You can find this tool's source code on <a target="_blank" href="https://github.com/borzunov/health.petals.ml">GitHub</a>.
+Page generated in {{ gen_time|round(2) }} sec.</footer>


### PR DESCRIPTION
As discussed on Discord, this change makes RPC calls in parallel for all hosted models.

I tested it in various scenarios, I even broke the Bloom pool for a moment to see if the health status is calculated correctly and everything seems to work.

The speedup is not *that* massive as I hoped, though. The real cause seems to be the connect timeout at 3 seconds. So although the stats for the responding nodes are retrieved immediately in one batch, one broken node in whole system is enough to make the page loading slow.